### PR TITLE
Allow configuration of multiple module paths

### DIFF
--- a/Debomatic/modules.py
+++ b/Debomatic/modules.py
@@ -56,7 +56,8 @@ class Module():
                 self._use_modules = True
         if dom.opts.has_option('modules', 'path'):
             mod_path = dom.opts.get('modules', 'path')
-            path.append(mod_path)
+            for p in mod_path.split(':'):
+                path.append(p)
         else:
             self._use_modules = False
         try:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -301,6 +301,7 @@ More on modules handling will be discussed in the :doc:`modules` section.
 * ``path``
 
  This option indicates the directory where Deb-o-Matic expects to find modules.
+ Multiple directories can be listed, separated with a colon (``:``).
 
  Suggested value: ``/usr/share/debomatic/modules``
 


### PR DESCRIPTION
This makes it easier to deploy local modules.

Making the configuration item a list would be cleaner
but would break configuration file backward compatibility.