### PR TITLE
Update docs to match BuildCleaner rename

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -170,7 +170,7 @@ This option indicates the extra options to pass to piuparts.
 
  Suggested value: ``--log-level=info``
 
-PrevBuildCleaner
+BuildCleaner
 ----------------
 
 This modules deletes obsolete files created during previous builds to avoid


### PR DESCRIPTION
The module was renamed in commit 631817b18f4003e13b751e1813d13578f562f3c6