### PR TITLE
Pass --no-arch-all to sbuild when building a binNMU

### DIFF
--- a/Debomatic/build.py
+++ b/Debomatic/build.py
@@ -204,6 +204,7 @@ class Build:
         if self.binnmu:
             command.insert(-1, '--binNMU=%s' % self.binnmu[0])
             command.insert(-1, '--make-binNMU=%s' % self.binnmu[1])
+            command.insert(-1, '--no-arch-all')
             buildlog = '%s+b%s_%s.build' % (packageversion, self.binnmu[0],
                                             architecture)
         else:


### PR DESCRIPTION
This is a workaround for https://bugs.debian.org/898946 in sbuild.

Debian binNMUs are not currently defined for Architecture:all packages,
but sbuild currently builds them by default unless --no-arch-all is
passed.

The resulting +b1_all.deb binaries can confuse apt so that it considers
the arch-dep packages from the same source uninstallable when they depend on the non-binNMU-versioned arch-indep packages.