### PR TITLE
Fix multiple module paths functionality

### DIFF
--- a/Debomatic/modules.py
+++ b/Debomatic/modules.py
@@ -60,9 +60,11 @@ class Module():
                 path.append(p)
         else:
             self._use_modules = False
+        modules = set()
         try:
-            modules = set([os.path.splitext(os.path.basename(m))[0] for m in
-                           glob(os.path.join(mod_path, '*.py'))])
+            for p in mod_path.split(':'):
+                modules |= set([os.path.splitext(os.path.basename(m))[0] for m in
+                               glob(os.path.join(p, '*.py'))])
         except OSError:
             self._use_modules = False
         if not modules:


### PR DESCRIPTION
The implementation in 1106a69cd3fb1aae0364474fd51b1181ac8e5856
was incomplete and didn't scan the paths for modules.

Apologies for the lack of testing on the previous related PR. This does seem to actually work for me.