### PR TITLE
Add Reprepro module

### DIFF
--- a/Debomatic/configuration.py
+++ b/Debomatic/configuration.py
@@ -45,6 +45,7 @@ modules = {'autopkgtest': {'options': str},
                       'authrequired': bool, 'user': str, 'passwd': str,
                       'success': str, 'failure': str, 'lintian': bool},
            'piuparts': {'options': str},
+           'reprepro': {'_binary': str, '_basedir': str, 'dists': str},
            'repository': {'gpgkey': str, 'pubring': str}}
 dists = {'suite': str, 'mirror': str, 'components': str,
          '_extramirrors': str, '_extrapackages': str}

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -269,6 +269,36 @@ repository.
 This option indicates the path where to look for the GPG keyring used to
 sign the Release file of the repository.
 
+Reprepro
+--------
+
+This is an alternative to the ```Repository``` module, using the
+```reprepro``` tool to manage package repositories. The main
+advantage over ```Repository``` is being able to handle different
+repositories for different distributions.
+
+Parameters
+..........
+
+* ```binary```
+
+The path name of the ```reprepro``` executable. The default is
+```/usr/bin/reprepro```.
+
+* ```basedir```
+
+The base ```reprepro``` directory in case that needs to be passed
+on the command line (the ```-b``` option).
+
+* ```dists```
+
+A list of distributions where this module should get triggered.
+If this list is not configured, nothing will be done.
+
+The built packages will be stored in the ```reprepro``` distribution
+with the same name as the build distribution, and ```reprepro```
+should be preconfigured to have these.
+
 SourceUpload
 ------------
 

--- a/modules/Reprepro.py
+++ b/modules/Reprepro.py
@@ -1,0 +1,93 @@
+# Deb-o-Matic - Reprepro module
+#
+# Copyright (C) 2011-2015 Luca Falavigna
+#                    2016 Niko Tyni
+#
+# Authors: Niko Tyni <ntyni@debian.org>
+#
+# Based on the Repository and Lintian modules
+#  by Luca Falavigna <dktrkranz@debian.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# Generate a local reprepro repository of built packages
+
+import os
+from subprocess import call
+from logging import debug, error, info
+
+
+class DebomaticModule_Reprepro:
+
+    def __init__(self):
+        self.reprepro = '/usr/bin/reprepro'
+        self.before   = [ 'BuildCleaner' ]
+
+    def post_build(self, args):
+        self.update_repository(args)
+
+    def update_repository(self, args):
+        if not args.success:
+            debug('Build failed, nothing to add with Reprepro')
+            return
+
+        binary = None
+        basedir = None
+        dists = []
+
+        if args.opts.has_section('reprepro'):
+            if args.opts.has_option('reprepro', 'basedir'):
+                basedir = args.opts.get('reprepro', 'basedir')
+            if args.opts.has_option('reprepro', 'binary'):
+                binary  = args.opts.get('reprepro', 'binary')
+            if args.opts.has_option('reprepro', 'dists'):
+                dists = args.opts.get('reprepro', 'dists').split()
+
+        if dists and not args.distribution in dists:
+            debug('Distribution %s not in Reprepro dists list, skipping' % args.distribution)
+            return
+
+        info('Adding build result to reprepro dist %s' % args.distribution)
+
+        if binary:
+            self.reprepro = binary
+
+        cmd = [self.reprepro,
+               '--ignore=surprisingbinary',
+               '--ignore=missingfile',
+               '--waitforlock=10',
+               'include',
+               args.distribution]
+
+        if basedir:
+            cmd[1:1] = ['--basedir', basedir ]
+
+        changesfile = None
+        resultdir = os.path.join(args.directory, 'pool', args.package)
+        files = os.listdir(resultdir)
+        for filename in files:
+            if filename.endswith('.changes'):
+                changesfile = os.path.join(resultdir, filename)
+                break
+
+        if changesfile and os.access(self.reprepro, os.X_OK):
+            info('calling %s on %s' % (self.reprepro, changesfile))
+            cmd.append(changesfile)
+            call(cmd)
+        else:
+            if not changesfile:
+                info('missing .changes? aborting')
+            if not os.access(self.reprepro, os.X_OK):
+                info('binary %s not accessible? aborting' % self.reprepro)
+


### PR DESCRIPTION
This is an alternative to the Repository module, using the reprepro tool
to manage package repositories. The main advantage over Repository is
being able to handle different repositories for different distributions.