### PR TITLE
Add latexmk for install deps

### DIFF
--- a/docs/requisites.rst
+++ b/docs/requisites.rst
@@ -16,6 +16,7 @@ The following packages are required to install documentation and translations:
 * texlive-fonts-recommended
 * texlive-latex-extra
 * gettext
+* latexmk
 
 Runtime requirements
 --------------------


### PR DESCRIPTION
`latexmk` is called in the `setup.py` file but is not available in some environments unless you install it manually; it's not listed in the dependencies so the `setup.py` steps fail until you install it.